### PR TITLE
#1080 make a markdown link for the indeed job description

### DIFF
--- a/pages/faq.md
+++ b/pages/faq.md
@@ -31,7 +31,7 @@ OLE virtual interns will be helping develop OLE’s BeLL (Basic e-Learning Libra
 As a part of this internship you will be working with software and languages including Git, GitHub, Gitter, Markdown, Vagrant, VirtualBox, Command Line/Terminal, Command Line/Terminal Scripts, Vim, CouchDB, Docker, HTML5, Javascript, and Node.js. 
 
 #### Q3: Where can I find more information about this internship?
-More information about the internship can be found here: http://www.indeed.com/jobs?q=%22virtual+software+engineer+intern%22&l=Cambridge%2C+MA
+More information about the internship can be found [here.](http://www.indeed.com/jobs?q=%22virtual+software+engineer+intern%22&l=Cambridge%2C+MA)
 
 #### Q4: What are the hours of the internship?
 This is an intensive internship that requires 16 hours of work each week. Work with your fellow interns and keep us updated in the [Gitter chat](https://gitter.im/open-learning-exchange/chat). 


### PR DESCRIPTION
This way it looks cleaner and you don't have to copy and paste the link in order to get to the job description page, you can just click!